### PR TITLE
HOTFIX: check data.go.kr secret_key.

### DIFF
--- a/apps/humanscape/management/commands/api.py
+++ b/apps/humanscape/management/commands/api.py
@@ -42,6 +42,13 @@ class Command(BaseCommand):
         per_page = 20
         payload = {"page": page, "perPage": per_page}
         res = requests.get(url, params=payload)
+        if res.status_code != 200:
+            self.stdout.write(
+                self.style.ERROR(
+                    f"Your secret_key is not correct. your key is {secret_key}"
+                )
+            )
+            return
         total_count = res.json().get("totalCount")
         max_page = (
             total_count // per_page


### PR DESCRIPTION
data.go.kr 에서 받은 secret_key가 잘못 들어갈 경우. 
api command를 종료합니다.